### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ add additional support.
 
 ```
 def deps do
-  [{:distillery, "~> 1.5"},
-   {:bootleg, "~> 0.7"}]
+  [{:distillery, "~> 1.5", runtime: false},
+   {:bootleg, "~> 0.7", runtime: false}]
 end
 ```
 


### PR DESCRIPTION
Set `:runtime` to `false` for bootleg and distillery.
As far as I could see, they're both not needed at runtime?

– https://github.com/bitwalker/distillery#installation

Cheers  👋 🙂 